### PR TITLE
Rename `Rubrik::Sign` param from `public_key` to `certificate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@ input_pdf = File.open("example.pdf", "rb")
 output_pdf = File.open("signed_example.pdf", "wb+") # needs read permission
 
 # Load Certificate(s)
-certificate = File.open("example_cert.pem", "rb")
-private_key = OpenSSL::PKey::RSA.new(certificate, "")
-certificate.rewind
-public_key = OpenSSL::X509::Certificate.new(certificate)
-certificate.close
+certificate_file = File.open("example_cert.pem", "rb")
+private_key = OpenSSL::PKey::RSA.new(certificate_file, "")
+certificate_file.rewind
+certificate = OpenSSL::X509::Certificate.new(certificate_file)
+certificate_file.close
 
 # Will write the signed document to `output_pdf`
-Rubrik::Sign.call(input_pdf, output_pdf, private_key:, public_key:, certificate_chain: [])
+Rubrik::Sign.call(input_pdf, output_pdf, private_key:, certificate:, certificate_chain: [])
 
 # Don't forget to close the files
 input_pdf.close

--- a/lib/rubrik/sign.rb
+++ b/lib/rubrik/sign.rb
@@ -9,10 +9,10 @@ module Rubrik
            input: T.any(File, Tempfile, StringIO),
            output: T.any(File, Tempfile, StringIO),
            private_key: OpenSSL::PKey::RSA,
-           public_key: OpenSSL::X509::Certificate,
+           certificate: OpenSSL::X509::Certificate,
            certificate_chain: T::Array[OpenSSL::X509::Certificate])
          .void}
-    def self.call(input, output, private_key:, public_key:, certificate_chain: [])
+    def self.call(input, output, private_key:, certificate:, certificate_chain: [])
       input.binmode
       output.reopen(T.unsafe(output), "wb+") if !output.is_a?(StringIO)
 
@@ -22,7 +22,7 @@ module Rubrik
 
       Document::Increment.call(document, io: output)
 
-      FillSignature.call(output, signature_value_ref:, private_key:, public_key:, certificate_chain:)
+      FillSignature.call(output, signature_value_ref:, private_key:, certificate:, certificate_chain:)
     end
   end
 end

--- a/test/rubrik/sign_test.rb
+++ b/test/rubrik/sign_test.rb
@@ -9,14 +9,14 @@ module Rubrik
       # Arrange
       input_pdf = File.open(SupportPDF["with_interactive_form"], "rb")
       output_pdf = StringIO.new
-      certificate = File.open("test/support/demo_cert.pem", "rb")
+      certificate_file = File.open("test/support/demo_cert.pem", "rb")
 
-      private_key = OpenSSL::PKey::RSA.new(certificate, "")
-      certificate.rewind
-      public_key = OpenSSL::X509::Certificate.new(certificate)
+      private_key = OpenSSL::PKey::RSA.new(certificate_file, "")
+      certificate_file.rewind
+      certificate = OpenSSL::X509::Certificate.new(certificate_file)
 
       # Act
-      Sign.call(input_pdf, output_pdf, private_key:, public_key:)
+      Sign.call(input_pdf, output_pdf, private_key:, certificate:)
 
       # Assert
       expected_output = File.open(SupportPDF["with_interactive_form.expected"], "rb")
@@ -35,7 +35,7 @@ module Rubrik
         assert_equal(expected_line, actual_line)
         end
     ensure
-      certificate&.close
+      certificate_file&.close
       output_pdf&.close
       input_pdf&.close
       expected_output&.close
@@ -45,14 +45,14 @@ module Rubrik
       # Arrange
       input_pdf = File.open(SupportPDF["without_interactive_form"], "rb")
       output_pdf = StringIO.new
-      certificate = File.open("test/support/demo_cert.pem", "rb")
+      certificate_file = File.open("test/support/demo_cert.pem", "rb")
 
-      private_key = OpenSSL::PKey::RSA.new(certificate, "")
-      certificate.rewind
-      public_key = OpenSSL::X509::Certificate.new(certificate)
+      private_key = OpenSSL::PKey::RSA.new(certificate_file, "")
+      certificate_file.rewind
+      certificate = OpenSSL::X509::Certificate.new(certificate_file)
 
       # Act
-      Sign.call(input_pdf, output_pdf, private_key:, public_key:)
+      Sign.call(input_pdf, output_pdf, private_key:, certificate:)
 
       # Assert
       expected_output = File.open(SupportPDF["without_interactive_form.expected"], "rb")
@@ -71,7 +71,7 @@ module Rubrik
         assert_equal(expected_line, actual_line)
       end
     ensure
-      certificate&.close
+      certificate_file&.close
       output_pdf&.close
       input_pdf&.close
       expected_output&.close


### PR DESCRIPTION
The old name was conceptually wrong, because what is embedded in the signature is the Signer's certificate and not only the public key.